### PR TITLE
Add song category field on song information

### DIFF
--- a/data-struct-lib/src/song.rs
+++ b/data-struct-lib/src/song.rs
@@ -13,6 +13,8 @@ use crate::janggu::{JangguFace, JangguStick};
 pub enum GameSongCategory {
     Kpop,
     TraditionalKpop,
+    Jpop,
+    Varierty,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Added categories
- K-POP
- Traditional K-POP
- Variety
- J-POP (Including anime song)

If you want more categories not listed above, feel free to write comment.