### PR TITLE
Delete unused note-editor project files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,10 +228,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chart-editor"
-version = "0.1.0"
-
-[[package]]
 name = "clang-sys"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,5 @@
 
 members = [
     "game",
-    "data-struct-lib",
-    "chart-editor"
+    "data-struct-lib"
 ]

--- a/chart-editor/Cargo.toml
+++ b/chart-editor/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "chart-editor"
-version = "0.1.0"
-edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/chart-editor/src/main.rs
+++ b/chart-editor/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
As note editor is developed on [separated repository](https://github.com/cau-overchaos/note-editor), note-editor project files are no longer needed.