### PR TITLE
fix: JangguStateWithTick update function bug fix

### DIFF
--- a/game/src/game/game_player/janggu_state_with_tick.rs
+++ b/game/src/game/game_player/janggu_state_with_tick.rs
@@ -70,16 +70,32 @@ impl JangguStateWithTick {
         self.궁채 = if state.궁채 == self.궁채.face {
             self.궁채.toggle_keydown(false)
         } else {
-            self.궁채
-                .toggle_keydown(true)
-                .change_keydown_timing_and_face(time, state.궁채)
+            // When user hit and take stick off the janggu, state.궁채 is None, and self.궁채.face is not None.
+            // So that state is not hit event. So make toggle_keydown false
+            if state.궁채 == None {
+                self.궁채
+                    .toggle_keydown(false)
+                    .change_keydown_timing_and_face(time, None)
+            } else {
+                self.궁채
+                    .toggle_keydown(true)
+                    .change_keydown_timing_and_face(time, state.궁채)
+            }
         };
         self.열채 = if state.열채 == self.열채.face {
             self.열채.toggle_keydown(false)
         } else {
-            self.열채
-                .toggle_keydown(true)
-                .change_keydown_timing_and_face(time, state.열채)
+            // When user hit and take stick off the janggu, state.궁채 is None, and self.궁채.face is not None.
+            // So that state is not hit event. So make toggle_keydown false
+            if state.열채 == None {
+                self.열채
+                    .toggle_keydown(false)
+                    .change_keydown_timing_and_face(time, None)
+            } else {
+                self.열채
+                    .toggle_keydown(true)
+                    .change_keydown_timing_and_face(time, state.열채)
+            }
         };
     }
 }


### PR DESCRIPTION
While I'm implementing hit sound, I found that there was a bug that when user press hit key and raise keyboard button, there was a two hit judgement(one at hit key, one at raise keyboard button). So There was two hit sound for pressing one key.So I think WTF is this.

So I fixed it. When user hit and take stick off the janggu, state.궁채 is None, and self.궁채.face is not None. So that state is not hit event. So make toggle_keydown false.
When user hit and take stick off the janggu, state.열채 is None, and self.열채.face is not None.So that state is not hit event. So make toggle_keydown false