### PR TITLE
Minor fixes and minor features: startx bug, window title change, vsync option

### DIFF
--- a/game/src/game/init.rs
+++ b/game/src/game/init.rs
@@ -11,6 +11,7 @@ pub struct InitGameOptions {
     pub width: Option<u32>,
     pub height: Option<u32>,
     pub fullscreen: bool,
+    pub vsync: bool,
 }
 
 pub(crate) fn init_game(janggu_bits: Arc<AtomicU8>, options: InitGameOptions) {
@@ -71,12 +72,14 @@ pub(crate) fn init_game(janggu_bits: Arc<AtomicU8>, options: InitGameOptions) {
     sdl_context.mouse().show_cursor(false);
 
     // create canvas
-    let mut canvas = window
-        .into_canvas()
-        .present_vsync()
-        .build()
-        .map_err(|e| e.to_string())
-        .expect("canvas initialization fail");
+    let mut canvas = if options.vsync {
+        window.into_canvas().present_vsync()
+    } else {
+        window.into_canvas()
+    }
+    .build()
+    .map_err(|e| e.to_string())
+    .expect("canvas initialization fail");
 
     canvas.clear();
     canvas.present();

--- a/game/src/game/init.rs
+++ b/game/src/game/init.rs
@@ -3,13 +3,9 @@ use std::{
     time::Instant,
 };
 
-use bidrum_data_struct_lib::song::GameSong;
 use kira::manager::{backend::DefaultBackend, AudioManager, AudioManagerSettings};
 
-use super::{
-    game_common_context::GameCommonContext, game_player::play_song, start::start_game,
-    title::render_title,
-};
+use super::{game_common_context::GameCommonContext, start::start_game, title::render_title};
 
 pub struct InitGameOptions {
     pub width: Option<u32>,
@@ -57,6 +53,10 @@ pub(crate) fn init_game(janggu_bits: Arc<AtomicU8>, options: InitGameOptions) {
 
     // set window fullscreen
     if options.fullscreen {
+        window.set_position(
+            sdl2::video::WindowPos::Positioned(0),
+            sdl2::video::WindowPos::Positioned(0),
+        );
         window
             .set_fullscreen(sdl2::video::FullscreenType::True)
             .expect("Failed to be fullscreen");

--- a/game/src/game/init.rs
+++ b/game/src/game/init.rs
@@ -24,7 +24,7 @@ pub(crate) fn init_game(janggu_bits: Arc<AtomicU8>, options: InitGameOptions) {
 
     // create window
     let mut window = video_subsystem
-        .window("rust-sdl2 demo: Video", 800, 600)
+        .window("BIDRUM", 800, 600)
         .position_centered()
         .opengl()
         .build()

--- a/game/src/main.rs
+++ b/game/src/main.rs
@@ -29,6 +29,9 @@ struct Args {
     /// Runs game in non-ullscreen
     #[arg(short, long)]
     windowed: bool,
+    /// Enables vsync or not? (Default: enabled in macos, disabled otherwise)
+    #[arg(long)]
+    vsync: Option<bool>,
 }
 
 fn main() {
@@ -70,6 +73,11 @@ fn main() {
             fullscreen: !args.windowed,
             height: args.window_height,
             width: args.window_width,
+            vsync: args.vsync.unwrap_or(if cfg!(target_os = "macos") {
+                true
+            } else {
+                false
+            }),
         },
     );
 }


### PR DESCRIPTION
- Fix a bug that fullscreen is not positioned correctly when launched with `startx` command only on linux
- Changed window title from `rust-sdl2 demo: Video`(..😅) to `BIDRUM`
- Added a feature that Vsync can be toggled with `--vsync true`(or `--vsync false`) argument. (It may be better to turn vsync off on linux)
   - Vsync is enabled by default on macos, and disabled on other systems.